### PR TITLE
Directional anisotropy added to detect and trascribe layers

### DIFF
--- a/R/bsims_animate.R
+++ b/R/bsims_animate.R
@@ -133,6 +133,10 @@ function(
       }
       Events[[i]] <- e
     }
+    ## direction added for vocalization events (NA for movement)
+    ## a=angle in degrees (0:360) relative to north clockwise
+    Events[[i]]$a <- ifelse(Events[[i]]$v == 1,
+      sample(0:359, nrow(Events[[i]]), replace=TRUE), NA)
   }
   x$vocal_rate <- vr
   x$move_rate <- mr

--- a/inst/shiny/bsimsH.R
+++ b/inst/shiny/bsimsH.R
@@ -122,7 +122,8 @@ ui <- navbarPage("bSims (H)",
       radioButtons("event", "Event type",
         c("Vocalization"="vocal",
           "Movement"="move",
-          "Both"="both"))
+          "Both"="both")),
+      sliderInput("dir_sens", "Anisotropy in tau due to direction", 0, 2, 1, 0.1)
     )
   ),
   tabPanel("Transcribe",
@@ -134,6 +135,7 @@ ui <- navbarPage("bSims (H)",
         selectInput("tint", "Time intervals", names(TINT)),
         selectInput("rint", "Distance intervals", names(RINT)),
         sliderInput("derr", "Distance error", 0, 1, 0, 0.1),
+        sliderInput("dbias", "Distance bias", 0, 2, 1, 0.1),
         radioButtons("condition", "Condition",
           c("1st event"="event1",
             "1st detection"="det1",
@@ -222,8 +224,9 @@ server <- function(input, output) {
       xy = c(0, 0),
       tau = c(input$tauV, input$tauM),
       dist_fun = dfun(),
-#      repel = input$repel,
-      event_type = input$event)
+      event_type = input$event,
+      direction=input$dir_sens != 1,
+      sensitivity=input$dir_sens)
   })
   m <- reactive({
     pr <- if (!input$oucount)
@@ -232,6 +235,7 @@ server <- function(input, output) {
       tint = TINT[[input$tint]],
       rint = RINT[[input$rint]],
       error = input$derr,
+      bias = input$dbias,
       condition = input$condition,
       event_type = input$event,
       perception = pr
@@ -314,10 +318,13 @@ server <- function(input, output) {
     ",\n  tau = c(", input$tauV, ", ", input$tauM, ")",
     ",\n  dist_fun = ", paste0(deparse(dfun()), collapse=''),
     ",\n  xy = c(0, 0)",
+    ",\n  direction = ", input$dir_sens != 1,
+    ",\n  sensitivity = ", input$dir_sens,
     ",\n  event_type = ", xq(input$event),
     ",\n  tint = ", xc(TINT[[input$tint]]),
     ",\n  rint = ", xc(RINT[[input$rint]]),
     ",\n  error = ", input$derr,
+    ",\n  bias = ", input$dbias,
     ",\n  condition = ", xq(input$condition),
     ",\n  perception = ", pr,
     ")", collapse="")

--- a/inst/tmp/etc.R
+++ b/inst/tmp/etc.R
@@ -7,6 +7,52 @@ library(mefa4)
 
 devtools::install_github("psolymos/bSims")
 
+
+## direction effects
+
+rbr <- c(0.5, 1, 1.5, Inf)
+tbr <- c(3, 5, 10)
+l <- bsims_init()
+p <- bsims_populate(l, 20)
+a <- bsims_animate(p, vocal_rate=1)
+#a$events[[1]]
+o1 <- bsims_detect(a, tau=1.5, sensitivity=1, direction=FALSE)
+o2 <- bsims_detect(a, tau=1.5, sensitivity=0.5, direction=TRUE)
+head(get_events(o1))
+head(get_detections(o1))
+dim(get_detections(o1))
+head(get_detections(o2))
+dim(get_detections(o2))
+
+x1 <- bsims_transcribe(o1, tint=tbr, rint=rbr)
+x2 <- bsims_transcribe(o2, tint=tbr, rint=rbr)
+x3 <- bsims_transcribe(o2, tint=tbr, rint=rbr, error=2)
+rowSums(x1$removal)
+rowSums(x2$removal)
+rowSums(x3$removal)
+estimate(x1)
+estimate(x2)
+estimate(x3)
+
+z <- list()
+for (i in 1:10) {
+  cat(".")
+  a <- bsims_animate(p, vocal_rate=1, initial_location = TRUE)
+  o1 <- bsims_detect(a, tau=1.5, sensitivity=1, direction=FALSE)
+  o2 <- bsims_detect(a, tau=1.5, sensitivity=0.5, direction=TRUE)
+  x1 <- bsims_transcribe(o1, tint=tbr, rint=rbr)
+  x2 <- bsims_transcribe(o2, tint=tbr, rint=rbr)
+  z[[i]] <- list(s1=round(100*rowSums(x1$removal)/sum(x1$removal)),
+   s2=round(100*rowSums(x2$removal)/sum(x2$removal)),
+    e1=estimate(x1),
+    e2=estimate(x2))
+}
+colMeans(t(sapply(z, "[[", "s1")))
+colMeans(t(sapply(z, "[[", "s2")))
+summary(t(sapply(z, "[[", "e1")))
+summary(t(sapply(z, "[[", "e2")))
+
+
 ## spatial patterns
 ## stupid
 f <- function(d) ifelse(d > 0, 0, 0)

--- a/inst/tmp/etc.R
+++ b/inst/tmp/etc.R
@@ -27,12 +27,24 @@ dim(get_detections(o2))
 x1 <- bsims_transcribe(o1, tint=tbr, rint=rbr)
 x2 <- bsims_transcribe(o2, tint=tbr, rint=rbr)
 x3 <- bsims_transcribe(o2, tint=tbr, rint=rbr, error=2)
-rowSums(x1$removal)
-rowSums(x2$removal)
-rowSums(x3$removal)
-estimate(x1)
-estimate(x2)
-estimate(x3)
+x4 <- bsims_transcribe(o2, tint=tbr, rint=rbr, bias=2, error=0)
+x5 <- bsims_transcribe(o2, tint=tbr, rint=rbr, bias=2, error=2)
+
+cbind(rowSums(x1$removal),
+  rowSums(x2$removal),
+  rowSums(x3$removal),
+  rowSums(x4$removal),
+  rowSums(x5$removal))
+c(estimate(x1)["tau"],
+  estimate(x2)["tau"],
+  estimate(x3)["tau"],
+  estimate(x4)["tau"],
+  estimate(x5)["tau"])
+## there are 3 key places where anisotropy can come in:
+## - sensitivity (tau impacted by direction)
+## - bias (perception in distance mean)
+## - error (perception in distance error)
+## the actual mechnaisms/magnitude is tricky to know...
 
 z <- list()
 for (i in 1:10) {

--- a/man/bsims_init.Rd
+++ b/man/bsims_init.Rd
@@ -32,7 +32,7 @@ bsims_animate(x, vocal_rate = 1, move_rate = 0, duration = 10,
 
 bsims_detect(x, xy = c(0, 0), tau = 1, dist_fun = NULL,
   event_type = c("vocal", "move", "both"),
-  sensitivity=1, ...)
+  sensitivity=1, direction=FALSE, ...)
 
 bsims_transcribe(x, tint = NULL, rint = Inf, error = 0,
   condition=c("event1", "det1", "alldet"),
@@ -149,8 +149,9 @@ conditioning type to define availability for each individual:
 \code{"alldet"}: all detections (counting the same individual multiple times).
 }
   \item{error}{
-log scale standard deviation for distance estimation error,
+log scale standard deviation (SD) for distance estimation error,
 see \code{\link{rlnorm2}}.
+When \code{direction=TRUE}, error changes based on the angle between the observer and the individual's (random) singing direction. When the bird faces the observer (0 degrees) SD is 0, when the bird is facing away (180 degrees) SD is \code{error}. In the range between 0-180 degrees the SD is changing according to the cosine of the degree: SD*(0.5-cos(degree*pi/180)/2).
 }
   \item{perception}{
 perceived number of individuals relative to the actual number of individuals.
@@ -164,8 +165,11 @@ receiving the signal. Can be of length 1 (applies to both vocal and movement eve
 or a named vector of length 2 (names should indicate which one
 is \code{"vocal"} or \code{"move"}). Sensitivity of 1 means that
 the process captured by \code{tau} is unaffected.
-Less than 1 values indicate lower sensitivity (effectively lowering tau),
-larger than 1 values indicate higher sensitivity (effectively lowering tau).
+Less than 1 values indicate lower sensitivity (effectively decreasing tau),
+larger than 1 values indicate higher sensitivity (effectively increasing tau).
+}
+  \item{direction}{
+logical. When \code{TRUE}, tau for vocalizations (not for movement) changes based on the angle between the observer and the individual's (random) singing direction. When the bird faces the observer (0 degrees) tau is unaffected, when the bird is facing away (180 degrees) tau is \code{sensitivity * tau}. In the range between 0-180 degrees the effect is changing according to the cosine of the degree (0.5-cos(degree*pi/180)/2).
 }
   \item{\dots}{
 other arguments passed to underlying functions.

--- a/man/bsims_init.Rd
+++ b/man/bsims_init.Rd
@@ -34,7 +34,8 @@ bsims_detect(x, xy = c(0, 0), tau = 1, dist_fun = NULL,
   event_type = c("vocal", "move", "both"),
   sensitivity=1, direction=FALSE, ...)
 
-bsims_transcribe(x, tint = NULL, rint = Inf, error = 0,
+bsims_transcribe(x, tint = NULL, rint = Inf,
+  error = 0, bias = 1,
   condition=c("event1", "det1", "alldet"),
   event_type=NULL, perception=NULL, ...)
 
@@ -152,6 +153,10 @@ conditioning type to define availability for each individual:
 log scale standard deviation (SD) for distance estimation error,
 see \code{\link{rlnorm2}}.
 When \code{direction=TRUE}, error changes based on the angle between the observer and the individual's (random) singing direction. When the bird faces the observer (0 degrees) SD is 0, when the bird is facing away (180 degrees) SD is \code{error}. In the range between 0-180 degrees the SD is changing according to the cosine of the degree: SD*(0.5-cos(degree*pi/180)/2).
+}
+  \item{bias}{
+nonnegative numeric, the distance estimation bias. The default value (1) means no bias, <1 indicates negative bias (perceived distance is less than true distance), >1 indicates positive bias (perceived distance is higher than true distance). This acts as a multiplier and can be combined with \code{error}.
+When \code{direction=TRUE}, bias changes based on the angle between the observer and the individual's (random) singing direction. When the bird faces the observer (0 degrees) perceived distance equals the true distance, when the bird is facing away (180 degrees) perceived distance is \code{bias} * true distance. In the range between 0-180 degrees the bias is changing according to the cosine of the degree: 1+(bias-1)*(0.5-cos(degree*pi/180)/2).
 }
   \item{perception}{
 perceived number of individuals relative to the actual number of individuals.


### PR DESCRIPTION
Bird vocalization direction is random (0-359 degrees). This is registered for all vocalizations in the behavior object.

Detection can be affected by direction relative to observer through the `sensitivity` argument combined with `direction=TRUE` in the detection layer.

The direction setting from the detection object then impacts the `error` and `bias` in the transcription layer.

Note: `bias` can be used without direction as well.